### PR TITLE
Allow snapshot selectors to handle plain tags

### DIFF
--- a/tests/test_extract_candidate.py
+++ b/tests/test_extract_candidate.py
@@ -1,0 +1,33 @@
+import unittest
+
+from check import extract_candidate
+
+
+HTML_WITH_MAIN = """
+<html>
+  <body>
+    <main>
+      <div class="content">
+        Başvuru son tarihi 31.12.2024
+      </div>
+    </main>
+    <section>
+      Diğer bilgi 01.01.2024
+    </section>
+  </body>
+</html>
+"""
+
+
+class ExtractCandidateTests(unittest.TestCase):
+    def test_snapshot_mode_allows_plain_tag_selector(self):
+        result = extract_candidate(HTML_WITH_MAIN, "main", snapshot_mode=True)
+        self.assertEqual(result, "31.12.2024")
+
+    def test_plain_hint_still_matches_text_in_regular_mode(self):
+        result = extract_candidate(HTML_WITH_MAIN, "deadline")
+        self.assertEqual(result, "31.12.2024")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update extract_candidate to attempt CSS selection when snapshot mode is active even if the selector looks like a plain tag
- add helper utilities for selector detection and safe selection while retaining hint-based fallback for regular runs
- add a regression test covering snapshot runs with a bare tag selector

## Testing
- python -m unittest discover -s tests
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dd7b1d50cc832f8146a3c0acbb23e5